### PR TITLE
Ajusta permissões do workflow Terraform no GitHub Actions para mínimo necessário  

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -1,5 +1,9 @@
 name: Terraform Format, Validate, and Test
 
+permissions:
+  contents: read
+  # Adicione permissões extras apenas se necessário
+
 on:
   push:
     branches:


### PR DESCRIPTION
Este pull request adiciona o bloco permissions ao arquivo `terraform.yml`, garantindo que o workflow utilize apenas o acesso mínimo necessário (`contents: read`). A alteração segue as recomendações de segurança do Prisma Cloud e da documentação oficial do GitHub, reduzindo riscos de permissões excessivas no pipeline CI/CD. Nenhuma permissão de escrita global é mais concedida por padrão. Correção para a `issue` https://github.com/Tech-Preta/terraform-sample/issues/1.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Atualizado o workflow do GitHub Actions para Terraform, especificando permissões de leitura para os conteúdos do repositório.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->